### PR TITLE
fix typos

### DIFF
--- a/src/components/LinearSoftmax.svelte
+++ b/src/components/LinearSoftmax.svelte
@@ -13,8 +13,8 @@
 	import { ga } from '~/utils/event';
 	import { EyeOutline, ZoomInOutline } from 'flowbite-svelte-icons';
 	import { fade } from 'svelte/transition';
-	import SoftmaxPopover from './popovers/SoftmaxPopover.svelte';
-	import LogitWeightPopover from './popovers/LogitWeightPopover.svelte';
+	import SoftmaxPopover from './Popovers/SoftmaxPopover.svelte';
+	import LogitWeightPopover from './Popovers/LogitWeightPopover.svelte';
 
 	export let className: string | undefined = undefined;
 

--- a/src/components/OperationGroup.svelte
+++ b/src/components/OperationGroup.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
 	import classNames from 'classnames';
 	import Operation from './Operation.svelte';
-	import DropoutPopover from './popovers/DropoutPopover.svelte';
+	import DropoutPopover from './Popovers/DropoutPopover.svelte';
 	import { tokens } from '~/store';
-	import LayerNormPopover from './popovers/LayerNormPopover.svelte';
-	import ActivationPopover from './popovers/ActivationPopover.svelte';
+	import LayerNormPopover from './Popovers/LayerNormPopover.svelte';
+	import ActivationPopover from './Popovers/ActivationPopover.svelte';
 	import * as d3 from 'd3';
-	import ResidualPopover from './popovers/ResidualPopover.svelte';
+	import ResidualPopover from './Popovers/ResidualPopover.svelte';
 	import gsap from 'gsap';
 	import { onClickReadMore } from '~/utils/event';
 

--- a/src/components/WeightPopovers.svelte
+++ b/src/components/WeightPopovers.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import QkvWeightPopover from './popovers/QKVWeightPopover.svelte';
+	import QkvWeightPopover from './Popovers/QKVWeightPopover.svelte';
 	import { weightPopover, tooltip } from '~/store';
 	import { fade } from 'svelte/transition';
-	import AttentionWeightPopover from './popovers/AttentionWeightPopover.svelte';
-	import MLPWeightPopover from './popovers/MLPWeightPopover.svelte';
-	import MLPDownWeightPopover from './popovers/MLPDownWeightPopover.svelte';
+	import AttentionWeightPopover from './Popovers/AttentionWeightPopover.svelte';
+	import MLPWeightPopover from './Popovers/MLPWeightPopover.svelte';
+	import MLPDownWeightPopover from './Popovers/MLPDownWeightPopover.svelte';
 
-	import LogitWeightPopover from './popovers/LogitWeightPopover.svelte';
+	import LogitWeightPopover from './Popovers/LogitWeightPopover.svelte';
 	import * as d3 from 'd3';
 	import { ArrowUpRightDownLeftOutline } from 'flowbite-svelte-icons';
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -70,8 +70,8 @@ export const selectedModel = writable(initialSelectedModel);
 export const modelMeta = derived(selectedModel, ($selectedModel) => modelMetaMap[$selectedModel]);
 
 // Temperature setting
-export const initialtTemperature = 0.8;
-export const temperature = writable(initialtTemperature);
+export const initialTemperature = 0.8;
+export const temperature = writable(initialTemperature);
 
 // Sampling
 export const sampling = writable<Sampling>({ type: 'top-k', value: 5 });


### PR DESCRIPTION
1. Fixed import paths typos for popover components across multiple files.
2. Fixed a typo in the `initialTemperature` variable name in `src/store/index.ts`.