### PR TITLE
Allow switching of sampling types using named Radio

### DIFF
--- a/src/components/Sampling.svelte
+++ b/src/components/Sampling.svelte
@@ -30,6 +30,7 @@
 			</div>
 			<div class="sampling-type-input flex">
 				<Radio
+					name="samplingType"
 					class={`type-btn ${disabled ? 'disabled' : ''}`}
 					inline
 					value="top-k"
@@ -48,6 +49,7 @@
 					color="purple">Top-k</Radio
 				>
 				<Radio
+					name="samplingType"
 					class={`type-btn ${disabled ? 'disabled' : ''}`}
 					inline
 					value="top-p"


### PR DESCRIPTION
After loading the main page, I tried to switch sampling types back and forth. However, when I switched from Top-k to Top-p, I found that both buttons always ended up selected, and I couldn't manage to deselect either. To switch back to Top-k, I had to refresh the page, meaning I lost my generated trajectory. I am assuming from [the variable updated by the Radios](https://github.com/poloclub/transformer-explainer/blob/b99a8215b6ddb2b291b5f217c7dbb82997158400/src/components/Sampling.svelte#L31) that `sampling_type` is only supposed to be one of Top-k or Top-p, but not both.

Issue reproduced on Firefox 140.0.4 (aarch64) and Safari Version 18.5, and shown in the video below.

https://github.com/user-attachments/assets/756d1f60-6e21-4b26-b309-17c7467eddc8

I was able to fix this locally by giving the same `name` to the each `Radio`. Video of local version shown below.

https://github.com/user-attachments/assets/9774e9e8-c3c1-4ffa-abc9-6dfec9ebe800

Taller videos showing the softmaxed values are below.

https://github.com/user-attachments/assets/528ef45f-b74b-490e-a6c0-6cfa374361d2

https://github.com/user-attachments/assets/414ff9f1-8820-44b1-936f-8afec53ebff4
