### PR TITLE
Clarify attention output projection

### DIFF
--- a/src/components/Attention.svelte
+++ b/src/components/Attention.svelte
@@ -139,8 +139,8 @@
 								</div>
 							{/each}
 							<Tooltip class="popover" triggeredBy={'.step.attention .out .cell'} placement="right"
-								>Attention Out, Head 1, vector({$modelMeta.dimension /
-									$modelMeta.attention_head_num})</Tooltip
+								>Attention Out before concatenation and projection, Head {$attentionHeadIdx + 1},
+								vector({$modelMeta.dimension / $modelMeta.attention_head_num})</Tooltip
 							>
 						</div>
 					</div>

--- a/src/components/article/Article.svelte
+++ b/src/components/article/Article.svelte
@@ -328,11 +328,12 @@
 			<h4>Step 4: Output and Concatenation</h4>
 			<p>
 				The model uses the masked self-attention scores and multiplies them with the
-				<span class="v-color">Value</span> matrix to get the
-				<span class="purple-color">final output</span>
-				of the self-attention mechanism. GPT-2 has <code>12</code> self-attention heads, each capturing
-				different relationships between tokens. The outputs of these heads are concatenated and passed
-				through a linear projection.
+				<span class="v-color">Value</span> matrix to get each head's attention output. GPT-2 has
+				<code>12</code> self-attention heads, each capturing different relationships between tokens.
+				The outputs of these heads are concatenated into one vector and then passed through the
+				attention block's learned output projection matrix (<code>c_proj</code>) before the result
+				flows to the next layer. The projection matrix is part of the model computation, but it is
+				not drawn as a separate matrix in this visualization.
 			</p>
 		</div>
 	</div>

--- a/src/utils/textbookPages.ts
+++ b/src/utils/textbookPages.ts
@@ -333,7 +333,7 @@ export const textPages: TextbookPage[] = [
 		id: 'output-concatenation',
 		title: 'Attention Output & Concatenation',
 		content:
-			'<p>Each head <span class="highlight">multiplies its <span class="purple">attention scores</span> with the <span class="green">Value</span> embeddings to produce its attention output</span>—a refined representation of each token after considering context.</p><p>GPT-2 (small) has 12 such outputs, which are concatenated to form a single vector of the original size (768 numbers).</p>',
+			'<p>Each head <span class="highlight">multiplies its <span class="purple">attention scores</span> with the <span class="green">Value</span> embeddings to produce a head-specific attention output</span>—a refined representation of each token after considering context.</p><p>GPT-2 (small) concatenates the 12 head outputs, then applies the attention block\'s learned output projection matrix (<code>c_proj</code>) before sending the result to the next layer. This projection is part of the computation even though it is not drawn as a separate matrix here.</p>',
 		on: function () {
 			this.timeoutId = setTimeout(
 				() => {


### PR DESCRIPTION
## Summary

- Clarify that each attention head output is concatenated and then passed through GPT-2's attention output projection matrix (`c_proj`).
- Update the article and guided textbook copy so learners understand why `c_proj` is present in the code but not drawn as a separate matrix.
- Fix the attention output tooltip to refer to the selected head instead of always saying Head 1.

Fixes #71

## Verification

- `npx prettier --check src/components/Attention.svelte src/components/article/Article.svelte src/utils/textbookPages.ts`
- `git diff --check`
- `npm run check` could not complete because the current project baseline reports 499 existing errors unrelated to this PR.
- `SASS_PATH=. npm run build` compiles the app bundles, then fails during prerender because `sharp` was installed with scripts disabled and its native binary is unavailable in this local environment.
